### PR TITLE
Fixed scene update bug which is deprecated with blender2.8.

### DIFF
--- a/addons/FBXBundleExporter/op_modifier_apply.py
+++ b/addons/FBXBundleExporter/op_modifier_apply.py
@@ -46,7 +46,8 @@ class op(bpy.types.Operator):
 					bpy.context.view_layer.objects.active = objects[0]
 
 					modifiers.modifiers[self.modifier_index].process_objects(fileName, objects)
-
 					
-		bpy.context.scene.update()
+		layer = bpy.context.view_layer
+		layer.update()
+
 		return {'FINISHED'}


### PR DESCRIPTION
I was getting an error message when applying the LOD modifier. I'm not sure if there are other issues to fix, but at least the addon no longer throws an error.